### PR TITLE
Fixed issue when default image is deleted

### DIFF
--- a/services/SeomaticService.php
+++ b/services/SeomaticService.php
@@ -331,7 +331,7 @@ class SeomaticService extends BaseApplicationComponent
                         switch ($entryMeta['seoImageIdSource'])
                         {
                             case 'field':
-                                if (isset($element[$entryMeta['seoImageIdSourceField']]))
+                                if (isset($element[$entryMeta['seoImageIdSourceField']]->first()->id))
                                 {
                                     $entryMeta['seoImageId'] = $element[$entryMeta['seoImageIdSourceField']]->first()->id;
                                 }


### PR DESCRIPTION
 I created an entry that has an image field and an SEOMatic field in it. At some point I set the seo image to the image field and I got this error:

``` php
/Users/will_browar/Desktop/MAMP/rba-rochester-chamber-website/rba_craft/plugins/seomatic/services/SeomaticService.php(336)

switch ($entryMeta['seoImageIdSource'])
332                         {
333                             case 'field':
334                                 if (isset($element[$entryMeta['seoImageIdSourceField']]))
335                                 {
336                                     $entryMeta['seoImageId'] = $element[$entryMeta['seoImageIdSourceField']]->first()->id;
337                                 }
338                             break;
339                         }
```
