### PR TITLE
Allow plugin to be installable via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,9 @@
 {
+    "name": "nystudio107/seomatic",
+    "description": "A turnkey SEO implementation for Craft CMS that is comprehensive, powerful, and flexible",
+    "type": "craft-plugin",
     "require": {
-        "crodas/text-rank" : "dev-master"
+        "crodas/text-rank" : "dev-master",
+        "composer/installers": "~1.0"
     }
 }


### PR DESCRIPTION
`"type": "craft-plugin",` allows one to just require the plugin and have `composer/installers` know where Craft keeps plugins by default.

Publishing versions to Packagist would be ideal, as well.

Example in the wild:
https://github.com/boboldehampsink/export/blob/master/composer.json
https://packagist.org/packages/boboldehampsink/export
