### PR TITLE
Insure fully qualified image URLs

### DIFF
--- a/services/SeomaticService.php
+++ b/services/SeomaticService.php
@@ -536,6 +536,24 @@ class SeomaticService extends BaseApplicationComponent
     } /* -- extractTextFromMatrix */
 
 /* --------------------------------------------------------------------------------
+    Insure any URL is fully qualified
+-------------------------------------------------------------------------------- */
+
+    public function getFullyQualifiedUrl($url)
+    {
+	    if (preg_match("/^(https?:\/\/)/i", $url) !== 1 )
+	    {
+		    $siteUrl = craft()->getSiteUrl();
+	        if ($url[0] == '/')
+	        {
+	            $siteUrl = rtrim($siteUrl, '/');
+	        }
+	        $url = $siteUrl . $url;
+	    }
+        return $url;
+    }
+
+/* --------------------------------------------------------------------------------
     Set the entry-level meta
 -------------------------------------------------------------------------------- */
 
@@ -575,7 +593,7 @@ class SeomaticService extends BaseApplicationComponent
             {
                 $image = craft()->assets->getFileById($entryMeta['seoImageId']);
                 if ($image)
-                    $meta['seoImage'] = $image->url;
+                    $meta['seoImage'] = $this->getFullyQualifiedUrl( $image->url );
                 else
                     $meta['seoImage'] = '';
                 unset($meta['seoImageId']);
@@ -955,7 +973,7 @@ class SeomaticService extends BaseApplicationComponent
         {
             $image = craft()->assets->getFileById($siteMeta['siteSeoImageId']);
             if ($image)
-                $siteMeta['siteSeoImage'] = $image->url;
+                $siteMeta['siteSeoImage'] = $this->getFullyQualifiedUrl( $image->url );
             else
                 $siteMeta['siteSeoImage'] = '';
         }
@@ -1022,7 +1040,7 @@ class SeomaticService extends BaseApplicationComponent
         $identity['genericOwnerImageId'] = $settings['genericOwnerImageId'];
         $image = craft()->assets->getFileById($settings['genericOwnerImageId']);
         if ($image)
-            $identity['genericOwnerImage'] = $image->url;
+            $identity['genericOwnerImage'] = $this->getFullyQualifiedUrl( $image->url );
         else
             $identity['genericOwnerImage'] = '';
         $identity['genericOwnerTelephone'] = $settings['genericOwnerTelephone'];
@@ -1366,7 +1384,7 @@ class SeomaticService extends BaseApplicationComponent
         $creator['genericCreatorImageId'] = $settings['genericCreatorImageId'];
         $image = craft()->assets->getFileById($settings['genericCreatorImageId']);
         if ($image)
-            $creator['genericCreatorImage'] = $image->url;
+            $creator['genericCreatorImage'] = $this->getFullyQualifiedUrl( $image->url );
         else
             $creator['genericCreatorImage'] = '';
         $creator['genericCreatorTelephone'] = $settings['genericCreatorTelephone'];
@@ -1662,7 +1680,7 @@ class SeomaticService extends BaseApplicationComponent
                 {
                     $image = craft()->assets->getFileById($meta['seoImageId']);
                     if ($image)
-                        $meta['seoImage'] = $image->url;
+                        $meta['seoImage'] = $this->getFullyQualifiedUrl( $image->url );
                     else
                         $meta['seoImage'] = '';
                     unset($meta['seoImageId']);

--- a/twigextensions/SeomaticTwigExtension.php
+++ b/twigextensions/SeomaticTwigExtension.php
@@ -56,6 +56,7 @@ class SeomaticTwigExtension extends \Twig_Extension
             'truncateStringOnWord' => new \Twig_Filter_Method($this, 'truncateStringOnWord'),
             'encodeEmailAddress' => new \Twig_Filter_Method($this, 'encodeEmailAddress'),
             'extractTextFromMatrix' => new \Twig_Filter_Method($this, 'extractTextFromMatrix'),
+            'getFullyQualifiedUrl' => new \Twig_Filter_Method($this, 'getFullyQualifiedUrl'),
         );
     }
 
@@ -72,6 +73,7 @@ class SeomaticTwigExtension extends \Twig_Extension
             'truncateStringOnWord' => new \Twig_Function_Method($this, 'truncateStringOnWord'),
             'encodeEmailAddress' => new \Twig_Function_Method($this, 'encodeEmailAddress'),
             'extractTextFromMatrix' => new \Twig_Function_Method($this, 'extractTextFromMatrix'),
+            'getFullyQualifiedUrl' => new \Twig_Function_Method($this, 'getFullyQualifiedUrl'),
         );
     }
 
@@ -172,6 +174,18 @@ class SeomaticTwigExtension extends \Twig_Extension
 
         return $result;
     } /* -- extractTextFromMatrix */
+
+/* --------------------------------------------------------------------------------
+    Insure any URL is fully qualified. If the URL does not begin with http://
+    or https://, site URL will be prepended. 
+-------------------------------------------------------------------------------- */
+
+    public function getFullyQualifiedUrl($url)
+    {
+        $result = craft()->seomatic->getFullyQualifiedUrl($url);
+
+        return $result;
+    } /* -- getFullyQualifiedUrl */
 
 /* --------------------------------------------------------------------------------
     Get the current template path

--- a/variables/SeomaticVariable.php
+++ b/variables/SeomaticVariable.php
@@ -106,6 +106,18 @@ class SeomaticVariable
         return $result;
     } /* -- extractTextFromMatrix */
 
+/* --------------------------------------------------------------------------------
+    Insure any URL is fully qualified. If the URL does not begin with http://
+    or https://, site URL will be prepended. 
+-------------------------------------------------------------------------------- */
+
+    public function getFullyQualifiedUrl($url)
+    {
+        $result = craft()->seomatic->getFullyQualifiedUrl($url);
+
+        return $result;
+    } /* -- getFullyQualifiedUrl */
+
 /* ================================================================================
     INTERNAL methods for SEOmatic use
 ================================================================================ */


### PR DESCRIPTION
Because relative image URLs throw errors in Facebook Open Graph and Google structured data tests, I added a helper function to insure fully qualified URLs, and applied to all image meta.
