### PR TITLE
Addresses FR #45 by making meta content max lengths configurable. 

### DIFF
--- a/config.php
+++ b/config.php
@@ -8,14 +8,38 @@
  */
 
 return array(
-    // Controls whether SEOmatic will truncate the text in <title> tags to 70 characters.
-    // It is HIGHLY recommended that you leave this on, as search engines do not want
-    // <title> tags to be long, and long titles won't display well on mobile either.
-    "truncateTitleTags" => true,
 
-    // SEOmatic will render the Google Analytics <script> tag and code for you, if you
-    // enter a Google Analytics UID tracking code in the Site Identity settings.  It
-    // does not render the <script> tag if devMode is on, but here is an additional
-    // override for controlling it.
-    "renderGoogleAnalyticsScript" => true,
+    /*
+     * Controls whether SEOmatic will truncate the text in <title> tags to 70 characters.
+     * It is HIGHLY recommended that you leave this on, as search engines do not want
+     * <title> tags to be long, and long titles won't display well on mobile either.
+     */
+    'truncateTitleTags' => true,
+
+	/*
+     * Sets the maximum length for titles when `truncateTitleTags` is false.
+     */
+	'maxTitleLength' => 200,
+
+	/*
+     * Sets the maximum length for description text.
+	 * It is generally recommended to restrict description text to no longer than about 155-160 characters.
+	 * (In many cases, search engines may truncate description text to around this length, especially when using
+	 * the description text as a SERP snippet.)
+     */
+	'maxDescriptionLength' => 160,
+
+	/*
+     * Sets the maximum length for keywords text.
+     */
+	'maxKeywordsLength' => 200,
+
+    /*
+     * SEOmatic will render the Google Analytics <script> tag and code for you, if you
+     * enter a Google Analytics UID tracking code in the Site Identity settings.  It
+     * does not render the <script> tag if devMode is on, but here is an additional
+     * override for controlling it.
+     */
+    'renderGoogleAnalyticsScript' => true,
+
 );

--- a/services/SeomaticService.php
+++ b/services/SeomaticService.php
@@ -2025,7 +2025,11 @@ class SeomaticService extends BaseApplicationComponent
 
 /* -- Truncate seoTitle, seoDescription, and seoKeywords to recommended values */
 
-        $shouldTruncate = craft()->config->get("truncateTitleTags", "seomatic");
+        $shouldTruncate = craft()->config->get('truncateTitleTags', 'seomatic');
+        $maxTitleLength = craft()->config->get('maxTitleLength', 'seomatic');
+        $maxDescriptionLength = craft()->config->get('maxDescriptionLength', 'seomatic');
+        $maxKeywordsLength = craft()->config->get('maxKeywordsLength', 'seomatic');
+
         if ($shouldTruncate)
         {
             if ($seomaticSiteMeta['siteSeoTitlePlacement'] == "none")
@@ -2035,10 +2039,10 @@ class SeomaticService extends BaseApplicationComponent
         }
         else
         {
-            $titleLength = 200;
+            $titleLength = $maxTitleLength;
         }
 
-        $vars = array('seoTitle' => $titleLength, 'seoDescription' => 160, 'seoKeywords' => 200);
+        $vars = array('seoTitle' => $titleLength, 'seoDescription' => $maxDescriptionLength, 'seoKeywords' => $maxKeywordsLength);
 
         foreach ($vars as $key => $value)
         {


### PR DESCRIPTION
Adds `maxTitleLength`, `maxDescriptionLength`, and `maxKeywordsLength` config variables. (As a bonus, also replaces multi-line comments in the config file with nice block comments.) <3
