### PR TITLE
Fix error on PHP 5.4 empty() function

### DIFF
--- a/controllers/SeomaticController.php
+++ b/controllers/SeomaticController.php
@@ -120,7 +120,7 @@ class SeomaticController extends BaseController
 
                     curl_setopt($ch, CURLOPT_NOBODY, true);
                     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-                    if (empty(ini_get('open_basedir')))
+                    if ( ini_get('open_basedir') == false )
                         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
                     curl_setopt($ch, CURLOPT_USERAGENT,'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13');
                     curl_exec($ch);


### PR DESCRIPTION
Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error.
