### PR TITLE
Fix issue when passing a string containing the "à" character to _cleanupText()

### DIFF
--- a/services/SeomaticService.php
+++ b/services/SeomaticService.php
@@ -3235,7 +3235,7 @@ public function getFullyQualifiedUrl($url)
 
 /* -- remove excess whitespace */
 
-        $text = preg_replace('/\s{2,}/', ' ', $text);
+        $text = preg_replace('/\s{2,}/u', ' ', $text);
 
         $text = html_entity_decode($text);
         return $text;


### PR DESCRIPTION
It would return an empty string.