### PR TITLE
The 'Site Meta' data can now be retrieved from within a Twig template.

### DIFF
--- a/variables/SeomaticVariable.php
+++ b/variables/SeomaticVariable.php
@@ -513,6 +513,17 @@ class SeomaticVariable
     } /* -- renderRobotsTemplate */
 
 /* --------------------------------------------------------------------------------
+    Get the site meta record
+-------------------------------------------------------------------------------- */
+
+    public function getSiteMeta($locale=null)
+    {
+        if (!$locale)
+            $locale = craft()->language;
+        return craft()->seomatic->getSiteMeta($locale);
+    } /* -- getSiteMeta */
+
+/* --------------------------------------------------------------------------------
     Get the identity record
 -------------------------------------------------------------------------------- */
 


### PR DESCRIPTION
Adds functionality for templates to retrieve the data from the Site Meta section of the plugin.

This is a crucial piece of functionality required for a project I am working on so I can retrieve the Site Twitter Card Image Transform and Site Facebook OpenGraph Image Transform from within my template in order to apply that transform to a custom defined asset for Twitter and Facebook.