### PR TITLE
Fix typo on W3C references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@
 * [Added] Added 'Person' as a type for the Main Entity of Page
 * [Added] Added Vimeo Handle to Social Media settings
 * [Added] Added a 'globalMetaOverride' setting to config.php
-* [Added] SEOmetrics checks for HTML validity via the WC3 Validator
+* [Added] SEOmetrics checks for HTML validity via the W3C Validator
 * [Added] Added a Score % summary for each SEOmetrics category
 * [Added] SEOmetrics now includes Google Pagespeed Insights scores and Google Mobile Usability
 * [Added] SEOmetrics checks for SSL encryption via https

--- a/releases.json
+++ b/releases.json
@@ -271,7 +271,7 @@
             "[Added] Added 'Person' as a type for the Main Entity of Page",
             "[Added] Added Vimeo Handle to Social Media settings",
             "[Added] Added a 'globalMetaOverride' setting to config.php",
-            "[Added] SEOmetrics checks for HTML validity via the WC3 Validator",
+            "[Added] SEOmetrics checks for HTML validity via the W3C Validator",
             "[Added] Added a Score % summary for each SEOmetrics category",
             "[Added] SEOmetrics now includes Google Pagespeed Insights scores and Google Mobile Usability scores",
             "[Added] SEOmetrics checks for SSL encryption via https",

--- a/templates/_seo_metrics.twig
+++ b/templates/_seo_metrics.twig
@@ -190,12 +190,12 @@
                     <tr>
                         {% set totalStats = totalStats + 1 %}
                         <td class="text-center">{% if validatorStatus == "Valid" %}{% set totalPassed = totalPassed + 1 %}<span class="goodscore">{{ checkmark |raw }}</span>{% else %}<span class="badscore">{{ xmark |raw }}</span>{% endif %}</td>
-                        <td class="text-left"><strong>WC3 HTML Validity - </strong>WC3 HTML Validator status: {% if validatorStatus == "Valid" %}<span class="goodscore">{% else %}<span class="badscore">{% endif %}{{ validatorStatus }}</span>.  Results: {{ validatorErrors }} errors, {{ validatorWarnings }} warnings.  In addition to being important to ensure that your webpage displays properly, HTML validity can also affect web crawler's ability to parse and index your pages.  <a href="{{ validatorUrl }}" target="_blank">Learn More</a></td>
+                        <td class="text-left"><strong>W3C HTML Validity - </strong>W3C HTML Validator status: {% if validatorStatus == "Valid" %}<span class="goodscore">{% else %}<span class="badscore">{% endif %}{{ validatorStatus }}</span>.  Results: {{ validatorErrors }} errors, {{ validatorWarnings }} warnings.  In addition to being important to ensure that your webpage displays properly, HTML validity can also affect web crawler's ability to parse and index your pages.  <a href="{{ validatorUrl }}" target="_blank">Learn More</a></td>
                     </tr>
                 {% else %}
                     <tr>
                         <td class="text-center"><span class="attentionscore">{{ attentionmark |raw }}</span></td>
-                        <td class="text-left"><strong>WC3 HTML Validity - </strong>Unable to determine WC3 HTML validity.  Is this a valid, publicly accessible URL?  <a href="{{ validatorUrl }}" target="_blank">Learn More</a></td>
+                        <td class="text-left"><strong>W3C HTML Validity - </strong>Unable to determine W3C HTML validity.  Is this a valid, publicly accessible URL?  <a href="{{ validatorUrl }}" target="_blank">Learn More</a></td>
                     </tr>
                 {% endif %}
 


### PR DESCRIPTION
@khalwat Fix incorrect W3C references, mainly on the site validator template, but also the historical references on the releases.json and CHANGELOG.